### PR TITLE
This PR adds basic listing capabilities.

### DIFF
--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -6,6 +6,12 @@ class ScreenBrightnessError(Exception):
         self.message=message
         super().__init__(self.message)
 
+def list_monitors():
+    if platform.system() == 'Windows':
+        return windows.list_monitors()
+    elif platform.system() == 'Linux':
+        pass #return linux.list_monitors()
+
 def flatten_list(thick_list):
     '''
     internal function I use to flatten lists, because I do that often

--- a/screen_brightness_control/__main__.py
+++ b/screen_brightness_control/__main__.py
@@ -9,6 +9,7 @@ if __name__=='__main__':
     parser.add_argument('-f', '--fade', type=int, help='fade the brightness to this value')
     parser.add_argument('-v', '--verbose', action='store_true', help='any error messages will be more detailed')
     parser.add_argument('-V', '--version', action='store_true', help='print the current version')
+    parser.add_argument('-l', '--list', action='store_true', help='list all monitors')
 
     args = parser.parse_args()
     kw = {}
@@ -25,6 +26,8 @@ if __name__=='__main__':
         SBC.fade_brightness(args.fade, **kw)
     elif args.version:
         print(SBC.__version__)
+    elif args.list:
+        print(SBC.list_monitors())
     else:
         print("No valid arguments")
 

--- a/screen_brightness_control/windows.py
+++ b/screen_brightness_control/windows.py
@@ -199,6 +199,16 @@ class VCP():
         '''performs cleanup functions'''
         self.physical_monitors.close()
 
+def list_monitors():
+    global methods
+    displays = []
+    for m in methods:
+            displays.append(m.get_display_names())
+    return flatten_list(displays)
+        
+def list_monitors_with_method(method):
+    return method.get_display_names()
+
 def set_brightness(value, display=None, **kwargs):
     '''
     Sets the brightness for a display


### PR DESCRIPTION
Hello again,

Here's a very basic PR to add listing capability to the library.
For instance a program might want to discover the displays that your library can handle before trying to issue any command.

So I wrote a very basic option for that, and only for windows ATM, it allows a user to list the monitors.
It uses the get_display_names function of VCP and WMI and merges the result by just flattening the two lists.
As I don't have any monitor that uses WMI I don't know how the results would overlap, so I decide to not care about duplicates. 

If you accept the idea, it should probably be more polished and return results as pairs of int and str to avoid ambiguity relative to display names.

Apart from that, I was wondering if for a library it would make some sense to allow the client to specify which method to use to send these commands. Or the library could return a list of Monitor instances that use the right method to avoid unnecessary looping and error catching. 
