### PR TITLE
Fix an error reading subprocess output with str()

### DIFF
--- a/screen_brightness_control/linux.py
+++ b/screen_brightness_control/linux.py
@@ -285,7 +285,7 @@ class Light:
                     ]
                 )
             )
-        results = [int(round(float(str(i)), 0)) for i in results]
+        results = [int(round(float(i.decode()), 0)) for i in results]
         return results
 
 


### PR DESCRIPTION
I got errors running with light on linux. The command-line version would change my monitors brightness correctly but output that it failed. 

    $ python -m screen_brightness_control -s 100 -m light
    Boe CQ -> Failed

If I called it through python it would throw the following exception:

    File ".../.local/lib/python3.9/site-packages/screen_brightness_control/__init__.py", line 807, in get_brightness
      raise ScreenBrightnessError(f'Cannot get screen brightness: {error}')
    screen_brightness_control.ScreenBrightnessError: Cannot get screen brightness: 
      Boe CQ -> ValueError: could not convert string to float: "b'100.00\\n'"
      XBacklight -> ValueError: could not convert string to float: ''

Looks like output from a subprocess call got converted with str() instead of decode() giving `"b'100.00\\n'"` instead of `"100.00\n"`