### PR TITLE
fixed wrong info type returned by sbc.windows.get_display_info()

### DIFF
--- a/screen_brightness_control/windows.py
+++ b/screen_brightness_control/windows.py
@@ -86,7 +86,8 @@ def get_display_info() -> List[dict]:
 
             extras, desktop, laptop = [], 0, 0
             uid_keys = list(monitor_uids.keys())
-            for monitor in wmi.WmiMonitorDescriptorMethods():
+            monitors = wmi.WmiMonitorDescriptorMethods()
+            for monitor in monitors:
                 try:
                     model, serial, manufacturer, man_id, edid = None, None, None, None, None
                     instance_name = monitor.InstanceName.replace('_0', '', 1).split('\\')[2]
@@ -170,6 +171,13 @@ def get_display_info() -> List[dict]:
         except Exception:
             pass
         __cache__.store('windows_monitors_info_raw', info)
+
+        # return info only which has correct data
+        valid_info = []
+        for i in info:
+            if isinstance(i, dict):
+                valid_info.append(i)
+        info = valid_info
 
     return info
 

--- a/screen_brightness_control/windows.py
+++ b/screen_brightness_control/windows.py
@@ -86,8 +86,7 @@ def get_display_info() -> List[dict]:
 
             extras, desktop, laptop = [], 0, 0
             uid_keys = list(monitor_uids.keys())
-            monitors = wmi.WmiMonitorDescriptorMethods()
-            for monitor in monitors:
+            for monitor in wmi.WmiMonitorDescriptorMethods():
                 try:
                     model, serial, manufacturer, man_id, edid = None, None, None, None, None
                     instance_name = monitor.InstanceName.replace('_0', '', 1).split('\\')[2]
@@ -173,11 +172,7 @@ def get_display_info() -> List[dict]:
         __cache__.store('windows_monitors_info_raw', info)
 
         # return info only which has correct data
-        valid_info = []
-        for i in info:
-            if isinstance(i, dict):
-                valid_info.append(i)
-        info = valid_info
+        info = [i for i in info if isinstance(i, dict)]
 
     return info
 


### PR DESCRIPTION
The issue has been fixed by putting a check before returning info from ```sbc.windows.get_display_info()```.

The check placed is a very simple if statement that checks if every item in info list is a dictionary.