### PR TITLE
Another logic for handling `interval` of `fade_brightness()` within __init__.py

### DIFF
--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -448,10 +448,9 @@ class Display():
             # `interval` is the intended time between the start of each brightness change.
             next_change_start_time += interval
             sleep_time = next_change_start_time - time.time()
-            if sleep_time <= 0:
-                # Skip sleep if the scheduled time has already passed
-                continue
-            time.sleep(sleep_time)
+            # Skip sleep if the scheduled time has already passed
+            if sleep_time > 0:
+                time.sleep(sleep_time)
         else:
             # As `value` doesn't hit `finish` in loop, we explicitly set brightness to `finish`.
             # This also avoids an unnecessary sleep in the last iteration.

--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -173,6 +173,7 @@ def fade_brightness(
     blocking: bool = True,
     force: bool = False,
     logarithmic: bool = True,
+    strict_interval: bool = False,
     **kwargs
 ) -> Union[List[threading.Thread], List[Union[IntPercentage, None]]]:
     '''
@@ -190,6 +191,13 @@ def fade_brightness(
             This is because on most displays a brightness of 0 will turn off the backlight.
             If True, this check is bypassed
         logarithmic: follow a logarithmic brightness curve when adjusting the brightness
+        strict_interval: determines how the 'interval' is applied between brightness changes.
+            - If False, 'interval' is the time delay between the end of one brightness change and the
+            start of the next. This means the actual time between brightness changes will always be longer
+            than the specified 'interval', as it includes the time taken by the brightness change itself.
+            - If True, 'interval' is the intended time between the start of each brightness change.
+            However, if a brightness change takes longer than the specified 'interval', the actual
+            interval will be longer, as the next change can't start until the current one finishes.
         **kwargs: passed through to `filter_monitors` for display selection.
             Will also be passed to `get_brightness` if `blocking is True`
 
@@ -236,7 +244,8 @@ def fade_brightness(
             'interval': interval,
             'increment': increment,
             'force': force,
-            'logarithmic': logarithmic
+            'logarithmic': logarithmic,
+            'strict_interval': strict_interval
         })
         thread.start()
         threads.append(thread)
@@ -392,7 +401,8 @@ class Display():
         interval: float = 0.01,
         increment: int = 1,
         force: bool = False,
-        logarithmic: bool = True
+        logarithmic: bool = True,
+        strict_interval: bool = False
     ) -> IntPercentage:
         '''
         Gradually change the brightness of this display to a set value.
@@ -410,6 +420,13 @@ class Display():
                 often turns off the backlight
             logarithmic: follow a logarithmic curve when setting brightness values.
                 See `logarithmic_range` for rationale
+            strict_interval: determines how the 'interval' is applied between brightness changes.
+                - If False, 'interval' is the time delay between the end of one brightness change and the
+                start of the next. This means the actual time between brightness changes will always be longer
+                than the specified 'interval', as it includes the time taken by the brightness change itself.
+                - If True, 'interval' is the intended time between the start of each brightness change.
+                However, if a brightness change takes longer than the specified 'interval', the actual
+                interval will be longer, as the next change can't start until the current one finishes.
 
         Returns:
             The brightness of the display after the fade is complete.
@@ -439,11 +456,26 @@ class Display():
         self._logger.debug(
             f'fade {start}->{finish}:{increment}:logarithmic={logarithmic}')
 
+        # Record the time when the next brightness change should start
+        next_change_start_time = time.time()
         for value in range_func(start, finish, increment):
+            # 'value' is ensured not to hit 'finish' in loop, this will be handled in the final step.
             self.set_brightness(value, force=force)
-            time.sleep(interval)
 
-        if self.get_brightness() != finish:
+            if not strict_interval:
+                # 'interval' is the time delay between the end of one brightness change and the start of the next.
+                sleep_time = interval
+            else:
+                # 'interval' is the intended time between the start of each brightness change.
+                next_change_start_time += interval
+                sleep_time = next_change_start_time - time.time()
+                if sleep_time <= 0:
+                    # Skip sleep if the scheduled time has already passed
+                    continue
+            time.sleep(sleep_time)
+        else:
+            # As 'value' doesn't hit 'finish' in loop, we explicitly set brightness to 'finish'.
+            # This also avoids an unnecessary sleep in the last iteration.
             self.set_brightness(finish, force=force)
 
         return self.get_brightness()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -144,7 +144,7 @@ class TestFadeBrightness(BrightnessFunctionTest):
         args = (100,)
         # all the kwargs that get passed to `Display`
         kwargs: Dict[str, Any] = dict(
-            start=0, interval=0, increment=10, force=False, logarithmic=False, strict_interval=False
+            start=0, interval=0, increment=10, force=False, logarithmic=False
         )
         sbc.fade_brightness(*args, **kwargs)
         for index, mock_call in enumerate(spy.mock_calls):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -144,7 +144,7 @@ class TestFadeBrightness(BrightnessFunctionTest):
         args = (100,)
         # all the kwargs that get passed to `Display`
         kwargs: Dict[str, Any] = dict(
-            start=0, interval=0, increment=10, force=False, logarithmic=False
+            start=0, interval=0, increment=10, force=False, logarithmic=False, strict_interval=False
         )
         sbc.fade_brightness(*args, **kwargs)
         for index, mock_call in enumerate(spy.mock_calls):


### PR DESCRIPTION
Previously, `interval` was defined as the time delay between the end of one brightness change and the start of the next. This meant that the actual time between brightness changes was always longer than the specified interval, as it included the time taken by the brightness change itself. This resulted in the total fading time being longer than interval*steps, with the deviation increasing with more steps. This resulted in unpredictable time consumption.

This PR adds a new parameter `strict_interval` to the `fade_brightness()`. `interval`  can now be interpreted as the intended time between the start of each brightness change. However, if a brightness change takes longer than the specified interval, the actual interval will be longer, as the next change can't start until the current one finishes.

**test result:**
> start=1		finish=21
> \-----------------
> interval=0.01s	expected=0.2s
> before=1.94s	deviation=1.74s
>  after=1.46s	deviation=1.26s
> time_saved_percent='239.95%'
> \-----------------
> interval=0.05s	expected=1.0s
> before=2.58s	deviation=1.58s
>  after=1.63s	deviation=0.63s
> time_saved_percent='103.58%'
> \-----------------
> interval=0.1s	expected=2.0s
> before=3.70s	deviation=1.70s
>  after=2.19s	deviation=0.19s
> time_saved_percent='75.81%'
> \-----------------
> interval=0.5s	expected=10.0s
> before=11.62s	deviation=1.62s
>  after=10.19s	deviation=0.19s
> time_saved_percent='14.25%'
> \-----------------
> interval=1s	expected=20s
> before=22.17s	deviation=2.17s
>  after=20.21s	deviation=0.21s
> time_saved_percent='9.81%'
> \-----------------

**test code:**
```
import screen_brightness_control as sbc
import time

start = 1       # included
finish = 21     # included
intervals = [0.01, 0.05, 0.1, 0.5, 1]
print(f"{start=}\t\t{finish=}")
print("-----------------")

for interval in intervals:
    expected = interval*abs(finish-start)
    print(f"{interval=}s\t{expected=}s")
    kwargs = {"finish": finish, "start": start, "increment": 1, "interval": interval, "logarithmic": False, "display": 0}
    
    t1 = time.time()
    kwargs["strict_interval"] = False
    sbc.fade_brightness(**kwargs)
    t2 = time.time()
    before = t2-t1
    deviation = before-expected
    print(f"{before=:.2f}s\t{deviation=:.2f}s")
    
    kwargs["strict_interval"] = True
    sbc.fade_brightness(**kwargs)
    t3 = time.time()
    after = t3-t2
    deviation = after-expected
    print(f" {after=:.2f}s\t{deviation=:.2f}s")
    
    time_saved = before-after
    time_saved_percent = f"{time_saved/expected*100:.2f}%" if expected != 0 else "can not be calculated"
    print(f"{time_saved_percent=}")
    print("-----------------")

```
This change makes the time consumption of `fade_brightness()` more predictable. Note that this PR is not intended to make the time consumption equal to the expectation, but to bring it closer.

Furthermore, I recommend removing the `strict_interval` and making this new interval handling logic the default and only method.