### PR TITLE
Fix `allow_duplicates` behavior in `set_brightness()` for relative string values

### DIFF
--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -120,38 +120,12 @@ def set_brightness(
     if isinstance(value, str) and ('+' in value or '-' in value):
         output: List[Union[IntPercentage, None]] = []
         for monitor in filter_monitors(display=display, method=method, allow_duplicates=allow_duplicates):
-            if allow_duplicates:
-                # duplicates share the identical indentifers except for the index.
-                identifier = monitor['index']
-            else:
-                identifier = Display.from_dict(monitor).get_identifier()[1]
+            # `filter_monitors()` will raise an error if no valid displays are found
+            display_instance = Display.from_dict(monitor)
+            display_instance.set_brightness(value=value, force=force)
+            output.append(None if no_return else display_instance.get_brightness())
 
-            current_value = get_brightness(display=identifier, allow_duplicates=allow_duplicates)[0]
-            if current_value is None:
-                # invalid displays can return None. In this case, assume
-                # the brightness to be 100, which is what many displays default to.
-                logging.warning(
-                    'set_brightness: unable to get current brightness level for display with identifier'
-                    f' {identifier}. Assume value to be 100'
-                )
-                current_value = 100
-
-            result = set_brightness(
-                # don't need to calculate lower bound here because it will be
-                # done by the other path in `set_brightness`
-                percentage(value, current=current_value),
-                display=identifier,
-                force=force,
-                allow_duplicates=allow_duplicates,
-                verbose_error=verbose_error,
-                no_return=no_return
-            )
-            if result is None:
-                output.append(result)
-            else:
-                output += result
-
-        return output
+        return None if no_return else output
 
     if platform.system() == 'Linux' and not force:
         lower_bound = 1

--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -120,7 +120,11 @@ def set_brightness(
     if isinstance(value, str) and ('+' in value or '-' in value):
         output: List[Union[IntPercentage, None]] = []
         for monitor in filter_monitors(display=display, method=method, allow_duplicates=allow_duplicates):
-            identifier = Display.from_dict(monitor).get_identifier()[1]
+            if allow_duplicates:
+                # duplicates share the identical indentifers except for the index.
+                identifier = monitor['index']
+            else:
+                identifier = Display.from_dict(monitor).get_identifier()[1]
 
             current_value = get_brightness(display=identifier, allow_duplicates=allow_duplicates)[0]
             if current_value is None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -78,12 +78,10 @@ class TestSetBrightness(BrightnessFunctionTest):
             self.percentage_spy = mocker.spy(sbc, 'percentage')
 
         def test_relative_values_are_calculated(self, mocker: MockerFixture):
-            mocker.patch.object(sbc, 'get_brightness', new=lambda *a, **k: [10])
+            mocker.patch.object(sbc.Display, 'get_brightness', new=lambda *a, **k: 10)
             sbc.set_brightness('+5', display=0)
-            # check `percentage` is called
-            assert self.percentage_spy.call_args_list[0] == call('+5', current=10)
-            # check the result is passed back to `set_brightness`
-            assert self.setter_spy.mock_calls[1].args[0] == 15
+            # check `percentage` is called and returns the correct value
+            assert self.percentage_spy.spy_return == 15
 
         def test_current_value_if_get_brightness_fails(self, mocker: MockerFixture):
             '''

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -79,9 +79,14 @@ class TestSetBrightness(BrightnessFunctionTest):
 
         def test_relative_values_are_calculated(self, mocker: MockerFixture):
             mocker.patch.object(sbc.Display, 'get_brightness', new=lambda *a, **k: 10)
+            display = sbc.Display.from_dict(sbc.list_monitors_info()[0])
+            spy = mocker.spy(display.method, 'set_brightness')
+
             sbc.set_brightness('+5', display=0)
             # check `percentage` is called and returns the correct value
             assert self.percentage_spy.spy_return == 15
+            # check the result is passed to `set_brightness()` of `BrightnessMethod`
+            spy.assert_called_once_with(15, display=display.index)
 
         def test_current_value_if_get_brightness_fails(self, mocker: MockerFixture):
             '''


### PR DESCRIPTION
This PR addresses a bug related to the `allow_duplicates` in the `set_brightness()` when the `value` is a relative string value (e.g., "+20" or "-10").

During the process of adding pytest cases for this scenario, I noticed a discrepancy in the definition of "duplicates". In the current implementation, it is supposed that duplicates could occur in two scenarios:
1. The same monitor is connected through different interfaces at the same time.
2. Different monitors share identical identifiers, including EDID, due to careless manufacturer. 

In both scenarios, the `list_monitors_info()` function returns the same output: different indices but identical other fields. This behavior was observed on a Windows 11 system.

> [{'name': 'None Generic Monitor',
>   'model': 'Generic Monitor',
>   'serial': '',
>   'manufacturer': None,
>   'manufacturer_id': 'IPS',
>   'edid': '00ffffffffffff00261300280000000020210104c53e23782987e5a456509e260d5054210800d1c0010181c0a9c0010101010101010150d000a0f0703e80302035006b5c2100001e000000fc005532383047410a202020202020000000fd003090ffff8c010a202020202020000000ff000a20202020202020202020202002bc',
>   'method': screen_brightness_control.screen_brightness_control.windows.VCP,
>   'index': 0},
>  {'name': 'None Generic Monitor',
>   'model': 'Generic Monitor',
>   'serial': '',
>   'manufacturer': None,
>   'manufacturer_id': 'IPS',
>   'edid': '00ffffffffffff00261300280000000020210104c53e23782987e5a456509e260d5054210800d1c0010181c0a9c0010101010101010150d000a0f0703e80302035006b5c2100001e000000fc005532383047410a202020202020000000fd003090ffff8c010a202020202020000000ff000a20202020202020202020202002bc',
>   'method': screen_brightness_control.screen_brightness_control.windows.VCP,
>   'index': 1}]

However, in the mock modules (`helpers_mock.py` and `os_module_mock.py`), the first and third displays share the same index but have many different other fields.

> [{
>   'name': 'Brand Display1',
>   'model': 'Display1',
>   'manufacturer': 'Brand',
>   'manufacturer_id': 'BRD',
>   'serial': 'serial1',
>   'edid': '00ffffffffff00edid1',
>   'method': cls,
>   'index': 0
> }]
> [{
>   'name': 'Brand Display3',
>   'model': 'Display3',
>   'manufacturer': 'Brand',
>   'manufacturer_id': 'BRD',
>   'serial': 'serial3',
>   'edid': '00ffffffffff00edid3',
>   'method': cls,
>   'index': 0
> }]

Do you suggest any modifications around `allow_duplicates`?
