### PR TITLE
Make `fade_brightness()` thread stoppable for concurrent requests

### DIFF
--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -448,10 +448,9 @@ class Display():
             # `interval` is the intended time between the start of each brightness change.
             next_change_start_time += interval
             sleep_time = next_change_start_time - time.time()
-            if sleep_time <= 0:
-                # Skip sleep if the scheduled time has already passed
-                continue
-            time.sleep(sleep_time)
+            # Skip sleep if the scheduled time has already passed
+            if sleep_time > 0:
+                time.sleep(sleep_time)
         else:
             # As `value` doesn't hit `finish` in loop, we explicitly set brightness to `finish`.
             # This also avoids an unnecessary sleep in the last iteration.

--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -413,8 +413,9 @@ class Display():
             stoppable: whether this fade will be stopped by starting a new fade on the same display
 
         Returns:
-            The brightness of the display after the fade is complete.
-            See `.types.IntPercentage`
+            If `blocking` is `False`, returns a `threading.Thread` object representing the
+            thread in which the fade operation is running.
+            If `blocking` is `True`, returns the current brightness level after the fade operation completes.
 
             .. warning:: Deprecated
                This function will return `None` in v0.23.0 and later.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -229,22 +229,6 @@ class TestDisplay:
         display.set_brightness(50)
         return display
 
-    def test_singleton(self):
-        '''`Display` should be a singleton class that returns the same instance for the same input'''
-        monitors = sbc.list_monitors_info()
-
-        # Create instance for each monitor
-        for monitor in monitors:
-            sbc.Display.from_dict(monitor)
-
-        # Check that the same instance is returned
-        for monitor in monitors:
-            dict_repr = frozenset(list(monitor.items()))
-            assert sbc.Display._instances[dict_repr] == sbc.Display.from_dict(monitor)
-
-        # After two iterations, the `_instances` dict should still have the same length as the number of monitors
-        assert len(sbc.Display._instances) == len(monitors)
-
     class TestFadeBrightness:
         @pytest.mark.parametrize('value', [100, 0, 75, 50, 150, -10])
         def test_returns_int_percentage(self, display: sbc.Display, value: int):
@@ -336,7 +320,7 @@ class TestDisplay:
         def test_stoppable_kwarg(self, display: sbc.Display, mocker: MockerFixture):
             start = 1
             finish = 20             # smaller value could introduce errors; greater value will extend the test.
-            interval = 0.05         # smaller value could introduce errors.
+            interval = 0.05         # same as above
             steps = int((finish - start) / 2)   # half the steps to ensure the thread is still active when checking.
             duration = interval * (steps - 1)   # -1 because the first step is immediate.
 
@@ -346,7 +330,8 @@ class TestDisplay:
             def fade_brightness_thread(stoppable: bool):
                 '''mainly for Mypy to stop complaining about the return type of `display.fade_brightness`'''
                 return cast(threading.Thread,
-                            display.fade_brightness(finish, interval=interval, blocking=False, stoppable=stoppable))
+                            display.fade_brightness(finish=finish, start=start, interval=interval,
+                                                    logarithmic=False, blocking=False, stoppable=stoppable))
 
             thread_0 = fade_brightness_thread(stoppable=True)
             thread_1 = fade_brightness_thread(stoppable=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -232,17 +232,18 @@ class TestDisplay:
     def test_singleton(self):
         '''`Display` should be a singleton class that returns the same instance for the same input'''
         monitors = sbc.list_monitors_info()
-        for i in range(2):
-            for monitor in monitors:
-                if i == 0:
-                    sbc.Display.from_dict(monitor)
-                else:
-                    # check that the same instance is returned
-                    dict_repr = frozenset(list(monitor.items()))
-                    assert sbc.Display._instances[dict_repr] == sbc.Display.from_dict(monitor)
-        else:
-            # after two iterations, the `_instances` dict should still have the same length as the number of monitors
-            assert len(sbc.Display._instances) == len(monitors)
+
+        # Create instance for each monitor
+        for monitor in monitors:
+            sbc.Display.from_dict(monitor)
+
+        # Check that the same instance is returned
+        for monitor in monitors:
+            dict_repr = frozenset(list(monitor.items()))
+            assert sbc.Display._instances[dict_repr] == sbc.Display.from_dict(monitor)
+
+        # After two iterations, the `_instances` dict should still have the same length as the number of monitors
+        assert len(sbc.Display._instances) == len(monitors)
 
     class TestFadeBrightness:
         @pytest.mark.parametrize('value', [100, 0, 75, 50, 150, -10])
@@ -356,7 +357,7 @@ class TestDisplay:
             # which occurs right after the first thread starts and before the second thread can signal it to stop.
             expected_call_count = steps * 1 + 1
             # Allow for a small margin of error due to one incomplete last step
-            assert expected_call_count - call_count <= 1
+            assert 0 <= expected_call_count - call_count <= 1
 
             # The fades below can't be stopped but they will halt the two above, which is essential for call count.
             thread_2 = fade_brightness_thread(stoppable=False)
@@ -367,7 +368,7 @@ class TestDisplay:
             call_count = len(setter.mock_calls) - call_count
             expected_call_count = steps * 2
             # Allow for a small margin of error due to two incomplete last steps
-            assert expected_call_count - call_count <= 2
+            assert 0 <= expected_call_count - call_count <= 2
 
             # Ensure all threads complete to prevent interference with subsequent tests.
             while threading.active_count() > 1:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -337,7 +337,7 @@ class TestDisplay:
             setter = mocker.patch.object(display, 'set_brightness', autospec=True)
 
             duration = 0.1          # seconds to run the fade
-            interval = 0.02         # seconds between each step
+            interval = 0.01         # seconds between each step
             steps = int(duration / interval) + 1    # +1 because the start brightness is set without waiting
 
             def fade_brightness_thread(stoppable: bool):
@@ -368,6 +368,10 @@ class TestDisplay:
             expected_call_count = steps * 2
             # Allow for a small margin of error due to two incomplete last steps
             assert expected_call_count - call_count <= 2
+
+            # Ensure all threads complete to prevent interference with subsequent tests.
+            while threading.active_count() > 1:
+                time.sleep(interval)
 
     class TestFromDict:
         def test_returns_valid_instance(self, subtests):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -338,7 +338,8 @@ class TestDisplay:
 
             duration = 0.1          # seconds to run the fade
             interval = 0.02         # seconds between each step
-            duration += interval/2  # add a little extra time to ensure the last brightness set is completed
+            # add a little extra time to ensure the last brightness set is completed. Warning: this is a bit of a hack
+            duration += interval/4
             steps = int(duration / interval) + 1    # +1 because the start brightness is set without waiting
 
             def fade_brightness_thread(stoppable: bool):


### PR DESCRIPTION
## PR Summary

This PR introduces enhancements to the `fade_brightness()` method in the `Display` class, aimed at improving how multiple brightness fade requests are handled. Previously, executing several `fade_brightness()` calls in rapid succession risked initiating overlapping non-blocking threads, potentially causing display flickering. The updates ensure that only the most recent fade request is executed, while all earlier requests are efficiently terminated.

### Key Changes

- **One Physical Display -> One `Display` Instance -> One Fade Thread**

- **Singleton Pattern for Display Instances**: 
    - The PR enforces a singleton pattern for `Display` instances, ensuring that each physical display is associated with a unique `Display` instance. These instances are managed within a dictionary, `_instances`, centralizing the control of fade operations and ensuring coordinated execution across displays.

- **Thread Management with `_fade_thread`**:
    - An `_fade_thread` attribute has been introduced within each `Display` instance, allowing for the tracking of the thread currently handling the fade operation. This mechanism is crucial for identifying and halting any preceding fade operations when a new fade request is made, ensuring that only the latest request remains active.

- **Method Refactoring**:
    - The original `fade_brightness()` method has been renamed to `fade_brightness_thread()`, which now solely carries out the fade logic within a dedicated thread.

- **Unified Fade Adjustment Invocation**:
    - There are two ways to invoke the fade brightness adjustment: `sbc.fade_brightness()` and `sbc.Display.fade_brightness()`. Regardless of the method used, both share the same exclusive thread for a given display.

### Example Program Demonstrating the PR Benefits

```python
import tkinter as tk
import screen_brightness_control as sbc
import threading
import time

sbc.config.ALLOW_DUPLICATES = True
first_two_monitors = sbc.list_monitors_info()[:2]
display_0 = sbc.Display.from_dict(first_two_monitors[0])
display_1 = sbc.Display.from_dict(first_two_monitors[1])


def make_slider(label, command=None, extra_args=()):
    slider = tk.Scale(root, from_=0, to=100, length=200, orient=tk.HORIZONTAL, command=lambda val: command(val, *extra_args) if command else None)
    slider.pack()
    tk.Label(root, text=label).pack()
    return slider


def safe_set(slider, value):
    slider.config(state=tk.NORMAL)
    slider.set(value)
    slider.config(state=tk.DISABLED)


def adjust_brightness(val, display):
    # Adjust the brightness of a single monitor, using display.fade_brightness()
    display.fade_brightness(int(val), blocking=False)


def adjust_brightness_all(val):
    # Adjust the brightness of all monitors, using sbc.fade_brightness()
    sbc.fade_brightness(int(val), blocking=False, haystack=first_two_monitors)


def update_current_brightness():
    while True:
        current_brightness_0 = display_0.get_brightness()
        current_brightness_1 = display_1.get_brightness()
        thread_count = threading.active_count()
        try:
            safe_set(slider_current_0, current_brightness_0)
            safe_set(slider_current_1, current_brightness_1)
            thread_count_label.config(text=f"Thread Count: {thread_count}")
        except Exception as e:
            print(e)
        time.sleep(0.1)


root = tk.Tk()
root.title("Brightness Control")
root.attributes('-topmost', 1)

# Label for thread count
thread_count_label = tk.Label(root, text="Thread Count: 0", fg="white", bg="blue")
thread_count_label.pack()

# Slider for current_brightness
slider_current_0 = make_slider("Display 0 Current Brightness")
slider_current_1 = make_slider("Display 1 Current Brightness")

# Slider for user inputs
slider_user_all = make_slider("Display 0&1 Use sbc.fade_brightness()", adjust_brightness_all)
slider_user_0 = make_slider("Display 0 Use Display.fade_brightness()", adjust_brightness, extra_args=(display_0,))
slider_user_1 = make_slider("Display 1 Use Display.fade_brightness()", adjust_brightness, extra_args=(display_1,))

# Update the current brightness and thread count in a separate thread
threading.Thread(target=update_current_brightness, daemon=True).start()

root.mainloop()

