### PR TITLE
add `uid` field to monitor info dict

### DIFF
--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -266,9 +266,11 @@ def list_monitors_info(
             print('Method:', display['method'])
             # the EDID string associated with that display
             print('EDID:', display['edid'])
-            # the UID of that display
-            # On Windows, this is extracted from the InstanceName of WMI or DeviceID of win32api
-            print('UID:', display['uid'])
+            # The connection_uid of the display.
+            # On Windows, this identifier is derived from the InstanceName (WMI) or DeviceID (win32api),
+            # and represents the connection details (e.g., port, path) rather than the physical display itself.
+            # It changes if the display is connected to a different port or system.
+            print('connection_uid:', display['connection_uid'])
         ```
     '''
     return _OS_MODULE.list_monitors_info(
@@ -360,8 +362,8 @@ class Display():
     '''The name of the display, often the manufacturer name plus the model name'''
     serial: Optional[str] = None
     '''The serial number of the display or (if serial is not available) an ID assigned by the OS'''
-    uid: Optional[str] = None
-    '''Unique identifier for the display. On Windows, extracted from InstanceName of WMI or DeviceID of win32api'''
+    connection_uid: Optional[str] = None
+    """'UID for the display connection, extracted from InstanceName (WMI) or DeviceID (win32api) on Windows."""
 
     _logger: logging.Logger = field(init=False, repr=False)
     _fade_thread_dict: ClassVar[Dict[FrozenSet[Tuple[Any, Any]], threading.Thread]] = {}
@@ -493,7 +495,7 @@ class Display():
             model=display['model'],
             name=display['name'],
             serial=display['serial'],
-            uid=display.get('uid')
+            connection_uid=display.get('connection_uid')
         )
 
     def get_brightness(self) -> IntPercentage:
@@ -509,14 +511,14 @@ class Display():
     def get_identifier(self) -> Tuple[str, DisplayIdentifier]:
         '''
         Returns the `.types.DisplayIdentifier` for this display.
-        Will iterate through the EDID, serial, name, uid and index and return the first
+        Will iterate through the EDID, serial, name, connection_uid and index and return the first
         value that is not equal to None
 
         Returns:
             The name of the property returned and the value of said property.
             EG: `('serial', '123abc...')` or `('name', 'BenQ GL2450H')`
         '''
-        for key in ('edid', 'serial', 'name', 'uid'):
+        for key in ('edid', 'serial', 'name', 'connection_uid'):
             value = getattr(self, key, None)
             if value is not None:
                 return key, value
@@ -627,15 +629,15 @@ def filter_monitors(
                 # no monitor should be filtered out
                 return to_filter
             elif isinstance(display, int):
-                # 'display' variable should match the 'index' field of display info dict
-                # return all displays with matching index
-                return [monitor for monitor in to_filter if monitor['index'] == display]
+                # 'display' variable should be the index of the monitor
+                # return a list with the monitor at the index or an empty list if the index is out of range
+                return to_filter[display : display + 1]
             elif isinstance(display, str):
                 # 'display' variable should be an identifier of the monitor
                 # multiple monitors with the same identifier are allowed here, so return all of them
                 monitors = []
                 for monitor in to_filter:
-                    for identifier in ['edid', 'serial', 'name', 'uid'] + include:
+                    for identifier in ['connection_uid', 'edid', 'serial', 'name'] + include:
                         if display == monitor.get(identifier, None):
                             monitors.append(monitor)
                             break
@@ -645,7 +647,7 @@ def filter_monitors(
         for monitor in to_filter:
             # find a valid identifier for a monitor, excluding any which are equal to None
             added = False
-            for identifier in ['edid', 'serial', 'name', 'uid'] + include:
+            for identifier in ['connection_uid', 'edid', 'serial', 'name'] + include:
                 if monitor.get(identifier, None) is None:
                     continue
 

--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -266,6 +266,9 @@ def list_monitors_info(
             print('Method:', display['method'])
             # the EDID string associated with that display
             print('EDID:', display['edid'])
+            # the UID of that display
+            # On Windows, this is extracted from the InstanceName of WMI or DeviceID of win32api
+            print('UID:', display['uid'])
         ```
     '''
     return _OS_MODULE.list_monitors_info(
@@ -357,6 +360,8 @@ class Display():
     '''The name of the display, often the manufacturer name plus the model name'''
     serial: Optional[str] = None
     '''The serial number of the display or (if serial is not available) an ID assigned by the OS'''
+    uid: Optional[str] = None
+    '''Unique identifier for the display. On Windows, extracted from InstanceName of WMI or DeviceID of win32api'''
 
     _logger: logging.Logger = field(init=False, repr=False)
     _fade_thread_dict: ClassVar[Dict[FrozenSet[Tuple[Any, Any]], threading.Thread]] = {}
@@ -503,14 +508,14 @@ class Display():
     def get_identifier(self) -> Tuple[str, DisplayIdentifier]:
         '''
         Returns the `.types.DisplayIdentifier` for this display.
-        Will iterate through the EDID, serial, name and index and return the first
+        Will iterate through the EDID, serial, name, uid and index and return the first
         value that is not equal to None
 
         Returns:
             The name of the property returned and the value of said property.
             EG: `('serial', '123abc...')` or `('name', 'BenQ GL2450H')`
         '''
-        for key in ('edid', 'serial', 'name'):
+        for key in ('edid', 'serial', 'name', 'uid'):
             value = getattr(self, key, None)
             if value is not None:
                 return key, value
@@ -621,15 +626,15 @@ def filter_monitors(
                 # no monitor should be filtered out
                 return to_filter
             elif isinstance(display, int):
-                # 'display' variable should be the index of the monitor
-                # return a list with the monitor at the index or an empty list if the index is out of range
-                return to_filter[display:display + 1]
+                # 'display' variable should match the 'index' field of display info dict
+                # return all displays with matching index
+                return [monitor for monitor in to_filter if monitor['index'] == display]
             elif isinstance(display, str):
                 # 'display' variable should be an identifier of the monitor
                 # multiple monitors with the same identifier are allowed here, so return all of them
                 monitors = []
                 for monitor in to_filter:
-                    for identifier in ['edid', 'serial', 'name'] + include:
+                    for identifier in ['edid', 'serial', 'name', 'uid'] + include:
                         if display == monitor.get(identifier, None):
                             monitors.append(monitor)
                             break
@@ -639,7 +644,7 @@ def filter_monitors(
         for monitor in to_filter:
             # find a valid identifier for a monitor, excluding any which are equal to None
             added = False
-            for identifier in ['edid', 'serial', 'name'] + include:
+            for identifier in ['edid', 'serial', 'name', 'uid'] + include:
                 if monitor.get(identifier, None) is None:
                     continue
 

--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -492,7 +492,8 @@ class Display():
             manufacturer_id=display['manufacturer_id'],
             model=display['model'],
             name=display['name'],
-            serial=display['serial']
+            serial=display['serial'],
+            uid=display.get('uid')
         )
 
     def get_brightness(self) -> IntPercentage:

--- a/screen_brightness_control/__init__.py
+++ b/screen_brightness_control/__init__.py
@@ -631,7 +631,7 @@ def filter_monitors(
             elif isinstance(display, int):
                 # 'display' variable should be the index of the monitor
                 # return a list with the monitor at the index or an empty list if the index is out of range
-                return to_filter[display : display + 1]
+                return to_filter[display:display + 1]
             elif isinstance(display, str):
                 # 'display' variable should be an identifier of the monitor
                 # multiple monitors with the same identifier are allowed here, so return all of them

--- a/screen_brightness_control/types.py
+++ b/screen_brightness_control/types.py
@@ -46,7 +46,7 @@ Can be any one of the following properties of a display:
 - edid (str)
 - serial (str)
 - name (str)
-- uid (int)
+- connection_uid (str)
 - index (int)
 
 See `Display` for descriptions of each property and its type

--- a/screen_brightness_control/types.py
+++ b/screen_brightness_control/types.py
@@ -43,10 +43,10 @@ DisplayIdentifier = Union[int, str]
 '''
 Something that can be used to identify a particular display.
 Can be any one of the following properties of a display:
+- uid (str)
 - edid (str)
 - serial (str)
 - name (str)
-- connection_uid (str)
 - index (int)
 
 See `Display` for descriptions of each property and its type

--- a/screen_brightness_control/types.py
+++ b/screen_brightness_control/types.py
@@ -46,6 +46,7 @@ Can be any one of the following properties of a display:
 - edid (str)
 - serial (str)
 - name (str)
+- uid (int)
 - index (int)
 
 See `Display` for descriptions of each property and its type

--- a/screen_brightness_control/windows.py
+++ b/screen_brightness_control/windows.py
@@ -11,7 +11,7 @@ import pywintypes
 import win32api
 import win32con
 import wmi
-
+import re
 from . import filter_monitors, get_methods
 from .exceptions import EDIDParseError, NoValidDisplayError, format_exc
 from .helpers import EDID, BrightnessMethod, __Cache, _monitor_brand_lookup
@@ -139,7 +139,8 @@ def get_display_info() -> List[dict]:
                     'serial': serial,
                     'manufacturer': manufacturer,
                     'manufacturer_id': man_id,
-                    'edid': edid
+                    'edid': edid,
+                    'uid': uid_match.group(1) if (uid_match := re.search(r"UID(\d+)", instance_name)) else None,
                 }
                 if monitor.InstanceName in laptop_displays:
                     data['index'] = laptop

--- a/screen_brightness_control/windows.py
+++ b/screen_brightness_control/windows.py
@@ -140,7 +140,7 @@ def get_display_info() -> List[dict]:
                     'manufacturer': manufacturer,
                     'manufacturer_id': man_id,
                     'edid': edid,
-                    'connection_uid': uid_match.group(1) if (uid_match := re.search(r"UID(\d+)", instance_name)) else None,
+                    'connection_uid': match.group(1) if (match := re.search(r"UID(\d+)", instance_name)) else None,
                 }
                 if monitor.InstanceName in laptop_displays:
                     data['index'] = laptop

--- a/screen_brightness_control/windows.py
+++ b/screen_brightness_control/windows.py
@@ -140,7 +140,7 @@ def get_display_info() -> List[dict]:
                     'manufacturer': manufacturer,
                     'manufacturer_id': man_id,
                     'edid': edid,
-                    'connection_uid': match.group(1) if (match := re.search(r"UID(\d+)", instance_name)) else None,
+                    'uid': uid_match.group(1) if (uid_match := re.search(r"UID(\d+)", instance_name)) else None,
                 }
                 if monitor.InstanceName in laptop_displays:
                     data['index'] = laptop

--- a/screen_brightness_control/windows.py
+++ b/screen_brightness_control/windows.py
@@ -140,7 +140,7 @@ def get_display_info() -> List[dict]:
                     'manufacturer': manufacturer,
                     'manufacturer_id': man_id,
                     'edid': edid,
-                    'uid': uid_match.group(1) if (uid_match := re.search(r"UID(\d+)", instance_name)) else None,
+                    'connection_uid': uid_match.group(1) if (uid_match := re.search(r"UID(\d+)", instance_name)) else None,
                 }
                 if monitor.InstanceName in laptop_displays:
                     data['index'] = laptop

--- a/tests/mocks/helpers_mock.py
+++ b/tests/mocks/helpers_mock.py
@@ -14,6 +14,7 @@ class MockBrightnessMethod(BrightnessMethod):
             'serial': 'serial1',
             'edid': '00ffffffffff00edid1',
             'method': cls,
+            'uid': '1000',
             'index': 0
         }]
 

--- a/tests/mocks/helpers_mock.py
+++ b/tests/mocks/helpers_mock.py
@@ -14,7 +14,7 @@ class MockBrightnessMethod(BrightnessMethod):
             'serial': 'serial1',
             'edid': '00ffffffffff00edid1',
             'method': cls,
-            'connection_uid': '1000',
+            'uid': '1000',
             'index': 0
         }]
 

--- a/tests/mocks/helpers_mock.py
+++ b/tests/mocks/helpers_mock.py
@@ -14,7 +14,7 @@ class MockBrightnessMethod(BrightnessMethod):
             'serial': 'serial1',
             'edid': '00ffffffffff00edid1',
             'method': cls,
-            'uid': '1000',
+            'connection_uid': '1000',
             'index': 0
         }]
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -394,9 +394,9 @@ class TestDisplay:
             assert getattr(display, prop) == value
             assert value is not None
 
-        @pytest.mark.parametrize('prop', ['edid', 'serial', 'name', 'index'])
+        @pytest.mark.parametrize('prop', ['edid', 'serial', 'name', 'uid', 'index'])
         def test_returns_first_not_none_value(self, display: sbc.Display, prop: str):
-            all_props = ['edid', 'serial', 'name', 'index']
+            all_props = ['edid', 'serial', 'name', 'uid', 'index']
             for p in all_props:
                 if p == prop:
                     continue

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -387,9 +387,9 @@ class TestDisplay:
             assert getattr(display, prop) == value
             assert value is not None
 
-        @pytest.mark.parametrize('prop', ['edid', 'serial', 'name', 'connection_uid', 'index'])
+        @pytest.mark.parametrize('prop', ['uid', 'edid', 'serial', 'name', 'index'])
         def test_returns_first_not_none_value(self, display: sbc.Display, prop: str):
-            all_props = ['edid', 'serial', 'name', 'connection_uid', 'index']
+            all_props = ['uid', 'edid', 'serial', 'name', 'index']
             for p in all_props:
                 if p == prop:
                     continue
@@ -403,9 +403,9 @@ class TestDisplay:
             `get_identifier` should skip properties only if they are `None`.
             It's very easy to do an `if truthy` check but that's not what we want here.
             '''
-            display.edid = ''
+            display.uid = ''
             prop, value = display.get_identifier()
-            assert prop == 'edid' and value == ''
+            assert prop == 'uid' and value == ''
 
     def test_is_active(self, display: sbc.Display, mocker: MockerFixture):
         # normal operation, should return true

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -387,9 +387,9 @@ class TestDisplay:
             assert getattr(display, prop) == value
             assert value is not None
 
-        @pytest.mark.parametrize('prop', ['edid', 'serial', 'name', 'uid', 'index'])
+        @pytest.mark.parametrize('prop', ['edid', 'serial', 'name', 'connection_uid', 'index'])
         def test_returns_first_not_none_value(self, display: sbc.Display, prop: str):
-            all_props = ['edid', 'serial', 'name', 'uid', 'index']
+            all_props = ['edid', 'serial', 'name', 'connection_uid', 'index']
             for p in all_props:
                 if p == prop:
                     continue

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -339,12 +339,7 @@ class TestDisplay:
             # The second fade should have stopped the first one.
             assert not thread_0.is_alive() and thread_1.is_alive()
             call_count = len(setter.mock_calls)
-            # *1 because only the second (latest) fade should run and the first should be stopped.
-            # Extra increment (+1) is added due to the immediate setting of the start brightness in the first thread,
-            # which occurs right after the first thread starts and before the second thread can signal it to stop.
-            expected_call_count = steps * 1 + 1
-            # Allow for a small margin of error due to one incomplete last step
-            assert 0 <= expected_call_count - call_count <= 1
+            assert round(call_count / steps) == 1   # 1 stands for the expected number of running threads
 
             # The fades below can't be stopped but they will halt the two above, which is essential for call count.
             thread_2 = fade_brightness_thread(stoppable=False)
@@ -353,9 +348,7 @@ class TestDisplay:
             # Both two new threads should run without stopping.
             assert thread_2.is_alive() and thread_3.is_alive()
             call_count = len(setter.mock_calls) - call_count
-            expected_call_count = steps * 2
-            # Allow for a small margin of error due to two incomplete last steps
-            assert 0 <= expected_call_count - call_count <= 2
+            assert round(call_count / steps) == 2   # 2 stands for the expected number of running threads
 
             # Ensure all threads complete to prevent interference with subsequent tests.
             while threading.active_count() > 1:


### PR DESCRIPTION
This PR adds only `uid` field to monitor info dict.
This PR is derived from #40 

Furthermore, all the possible `duplicate monitors problem` will be gone without needing `ALLOW_DUPLICATES` in my case after this PR.

